### PR TITLE
Remove comments holders maximum width

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -45,6 +45,12 @@ body > .container, /* Footer */
   margin-right: 240px !important;
 }
 
+/* Comments */
+
+.comment-holder {
+  max-width: none !important;
+}
+
 /* New issues and Dashboard */
 
 #dashboard,


### PR DESCRIPTION
In issue discussion, comments were limited to a width of `780px` making the page look a bit inconsistent. I removed this `max-width` so that comments are fluid just as diffs snippets.
