### PR TITLE
Add Gist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Install a userstyle manager for your favorite browser:
 
 Then, copy-pasta the styles from `github-wide.css` into a new userstyle. Be sure to specify that it apply to sites beginning with `https://github.com/*`.
 
+In addition, you can apply styles from `gist-wide.css` to sites beginning with `https://gist.github.com/*`.
+
 ### Bug reports
 
 Open an issue or submit a pull request, please.

--- a/gist-wide.css
+++ b/gist-wide.css
@@ -1,0 +1,26 @@
+footer > .container, /* Footer */
+.header > .container, /* Site header */
+.pagehead > .container, /* All pageheads */
+.site-container > .container, /* List view */
+.site-container + .container /* Gist view */ {
+  width: 100% !important;
+  padding-left: 30px !important;
+  padding-right: 30px !important;
+}
+
+.gist {
+  padding-right: 0 !important;
+}
+
+.gist-sidebar {
+  margin-left: -170px;
+}
+
+.gist-with-sidebar .gist-content {
+  width: 100% !important;
+  padding-right: 200px;
+}
+
+.edit.container {
+  width: 100% !important;
+}

--- a/github-wide.css
+++ b/github-wide.css
@@ -2,9 +2,7 @@ body > .container, /* Footer */
 .site > .container, /* Misc views */
 .header > .container, /* Site header */
 .pagehead > .container, /* All pageheads */
-#site-container > .container, /* Misc views */
-.site-container > .container, /* Gist */
-.site-container + .container /* Gist */ {
+#site-container > .container /* Misc views */ {
   width: 100% !important;
   padding-left: 30px !important;
   padding-right: 30px !important;
@@ -101,23 +99,4 @@ button.discussion-sidebar-toggle {
 /* Profile avatar tooltip */
 .vcard-avatar {
   width: 230px !important;
-}
-
-/* Gist */
-
-.gist {
-  padding-right: 0 !important;
-}
-
-.gist-sidebar {
-  margin-left: -170px;
-}
-
-.gist-with-sidebar .gist-content {
-  width: 100% !important;
-  padding-right: 200px;
-}
-
-.edit.container {
-  width: 100% !important;
 }


### PR DESCRIPTION
Don't know if [github-wide](https://github.com/mdo/github-wide) is meant to also support Gist but I configured stylish to apply on `*.github.com` and saw gist.github.com was a bit broken with the custom stylesheet.
