### PR TITLE
Fixed issue with tooltips on discussion timeline

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -53,7 +53,6 @@ body > .container, /* Footer */
 }
 
 .discussion-timeline {
-  overflow: auto !important;
   float: none !important;
   width: auto !important;
   margin-right: 240px !important;


### PR DESCRIPTION
On discussion timelines when you hover over anything on the right side that has a tooltip, the tooltip can overflow behind the sidebar on the right.