### PR TITLE
Put the Gist sidebar on the foreground

### DIFF
--- a/gist-wide.css
+++ b/gist-wide.css
@@ -13,6 +13,7 @@ footer > .container, /* Footer */
 }
 
 .gist-sidebar {
+  position: relative;
   margin-left: -170px;
 }
 


### PR DESCRIPTION
There were some problem with the gist sidebar with the current version of the user style: some links in the sidebar were not clickable because the `.gist-content` div was displaying above the `.gist-sidebar`.

For example, we were not able to click the fields containing the clone URL or HTML snippet.
