### PR TITLE
Widen extended commit message under "..."

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -120,3 +120,8 @@ button.discussion-sidebar-toggle {
 .vcard-avatar {
   width: 230px !important;
 }
+
+/* Commits: extended message under "..." */
+.commit-desc pre {
+  max-width: none;
+}


### PR DESCRIPTION
Use all available width for extended commit message under "..." instead of GH's 770px:

![screenshot-fs8](https://cloud.githubusercontent.com/assets/1310400/7621517/184b765c-f9d0-11e4-9b18-135e79e25c34.png)