### PR TITLE
Limit max-width of timeline to 100%

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -56,6 +56,7 @@ body > .container, /* Footer */
 .discussion-timeline {
   float: none !important;
   width: auto !important;
+  max-width: calc(100% - 240px) !important;
   margin-right: 240px !important;
 }
 


### PR DESCRIPTION
An extremely long code line caused the layout to exceed window width and a horizontal window scrollbar appeared.

Test case:

```css
a {
    background-image: url("data:image/svg+xml !important;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' > <polygon points='0,0 50,100 100,0' fill='#888' stroke='#000' stroke-width='1' /> </svg>"); background: url("data:image/svg+xml !important;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' > <polygon points='0,0 50,100 100,0' fill='#888' stroke='#000' stroke-width='1' /> </svg>");
}
```

---

* 1280px browser window before the fix:

![bug-fs8](https://cloud.githubusercontent.com/assets/1310400/9137951/c7547e04-3d29-11e5-9fe3-036ea43644dd.png)

* After:

![fix-fs8](https://cloud.githubusercontent.com/assets/1310400/9137955/cb78bc70-3d29-11e5-85c6-a431d25455f6.png)
