### PR TITLE
Display full filenames when browsing repos

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -32,6 +32,11 @@
   width: 50%;
 }
 
+table.files td.content, table.files td.message {
+  max-width: auto;
+  width: auto;
+}
+
 /* Repo Next Code page */
 
 .with-full-navigation {


### PR DESCRIPTION
Allow the files table to auto size the file name and message columns to avoid cutting off long file names and make use of the extra width. Compare https://github.com/aws/aws-sdk-net/tree/master/sdk/src/Services/SQS/Generated/Model before and after the change.

Cons of this approach are that the column widths will no longer be consistent across pages, but I think this is an acceptable trade off. Interested to hear your thoughts.
