### PR TITLE
Fix profile avatar width

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -114,7 +114,7 @@ button.discussion-sidebar-toggle {
 /* Profile page */
 
 /* Profile avatar tooltip */
-.vcard-avatar {
+.u-photo .avatar {
   width: 230px !important;
 }
 
@@ -122,4 +122,3 @@ button.discussion-sidebar-toggle {
 .commit-desc pre {
   max-width: none;
 }
-


### PR DESCRIPTION
Stops the avatar width from being too wide on a user profile page.

Before:
<img width="648" src="https://user-images.githubusercontent.com/754567/32220831-4c7683c6-be87-11e7-8642-e3c358b3c3d2.png">

After:
<img width="650" alt="screen shot 2017-10-31 at 10 01 15 pm" src="https://user-images.githubusercontent.com/754567/32220836-5270b67a-be87-11e7-87c8-8ad448e245c8.png">
