### PR TITLE
Fixed Insights Network Graph

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -122,3 +122,9 @@ button.discussion-sidebar-toggle {
 .commit-desc pre {
   max-width: none;
 }
+
+/* Insights Network Graph */
+#network
+{
+  max-width: 730px;
+}


### PR DESCRIPTION
Sets a max width of the Insights Network Graph so the overflow doesn't appear when the panel is made wider.