### PR TITLE
update readme - userstyle manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,22 @@ I work at GitHub. This repo comes with absolutely no promise of an official full
 
 Install a userstyle manager for your favorite browser:
 
-* Chrome: https://chrome.google.com/webstore/detail/stylish/fjnbnpbmkenffdnngjfgmeleoegfcffe?hl=en
-* Firefox: https://addons.mozilla.org/en-US/firefox/addon/stylish/ (be sure to place the CSS inside the `@-moz-document domain("github.com")` block)
+#### Stylus
+Website: [Stylish](http://add0n.com/stylus.html)
+* Chrome: https://chrome.google.com/webstore/detail/clngdbkpkpeebahjckkjfobafhncgmne
+* Firefox: https://addons.mozilla.org/firefox/addon/styl-us/
+* Opera: https://addons.opera.com/extensions/details/stylus/
+
+
+#### Stylish
+> Due to privacy concerns (extension has permission to all your browser data) Stylus is recommended.
+
+Website: [userstyles.org](http://userstyles.org)
+* Chrome: *currently not available* (checked 2018-07-19)
+* Firefox: https://addons.mozilla.org/firefox/addon/stylish/ (be sure to place the CSS inside the `@-moz-document domain("github.com")` block)
+* Opera: *currently not available* (checked 2018-07-19)
+
+#### Other
 * Safari: http://code.grid.in.th/
 
 Then, copy-pasta the styles from `github-wide.css` into a new userstyle. Be sure to specify that it apply to sites beginning with `https://github.com/*`.
@@ -26,7 +40,7 @@ In addition, you can apply styles from `gist-wide.css` to sites beginning with `
 
 #### Userstyles.org
 
-If you use the Stylish addon on Chrome or Firefox you can find one-click installs including automatic updates via the packages below.
+If you use the Stylus (or Stylish) addon you can find one-click installs including automatic updates via the packages below.
 
 * [GitHub Wide](https://userstyles.org/styles/108591/github-wide)
 * [GitHub Gist Wide](https://userstyles.org/styles/108592/github-gist-wide)


### PR DESCRIPTION
Due to major privacy concerns I would suggest not recommending the _stylish_ addon anymore. The change was implemented pretty long ago but I did not see it until a few days ago.
Also the addons for chrome and opera are missing from the stores at the moment.

Stylish has full access to all browser data. Why? Analytics.
Is it opt-in? No. -> not even allowed for EU users. Should be best practice in the first place.

I suggest recommending Stylus. Works the same.