### PR TITLE
Overhaul to remove outdated styles, refresh for UI changes

### DIFF
--- a/gist-wide.css
+++ b/gist-wide.css
@@ -1,11 +1,18 @@
-footer > .container, /* Footer */
-.header > .container, /* Site header */
-.pagehead > .container, /* All pageheads */
-.site-container > .container, /* List view */
-.site-container + .container /* Gist view */ {
+.container,
+.container-lg {
   width: 100% !important;
-  padding-left: 30px !important;
+  max-width: 100% !important;
   padding-right: 30px !important;
+  padding-left: 30px !important;
+}
+
+.container .container {
+  padding-right: 0 !important;
+  padding-left: 0 !important;
+}
+
+.gisthead {
+  padding-left: 0 !important;
 }
 
 .gist {
@@ -24,4 +31,12 @@ footer > .container, /* Footer */
 
 .edit.container {
   width: 100% !important;
+}
+
+/* Gist profile */
+.h-card {
+  padding-right: 30px !important;
+}
+.h-card img {
+  max-width: 230px !important;
 }

--- a/github-wide.css
+++ b/github-wide.css
@@ -82,7 +82,6 @@
   position: relative !important;
 }
 
-.dashboard-sidebar,
 .new-issue-form .discussion-sidebar {
   position: absolute !important;
   top: 0 !important;
@@ -95,14 +94,6 @@ button.discussion-sidebar-toggle {
 
 .timeline-new-comment {
   max-width: none !important;
-}
-
-/* Dashboard */
-/* Note that this won't be needed if we actually flipped the DOM order around. */
-
-.news {
-  float: none !important;
-  margin-right: 360px !important;
 }
 
 /* Commits: extended message under "..." */

--- a/github-wide.css
+++ b/github-wide.css
@@ -27,7 +27,8 @@
   width: calc(33.3% - 10px) !important;
 }
 
-.u-photo {
+.u-photo,
+.user-status-container {
   max-width: 250px;
 }
 .u-photo .avatar {

--- a/github-wide.css
+++ b/github-wide.css
@@ -52,10 +52,10 @@
 
 /* Issues/PRs */
 .discussion-sidebar {
-  width: 220px !important;
+  width: 280px !important;
 }
 .discussion-timeline {
-  width: calc(100% - 240px) !important;
+  width: calc(100% - 300px) !important;
 }
 /* Undo for profile timeline */
 .contribution-activity-listing .discussion-timeline {

--- a/github-wide.css
+++ b/github-wide.css
@@ -1,55 +1,65 @@
+/*
+ * Basic layout
+ */
+
 .container {
   width: 100% !important;
-  padding-left: 30px !important;
   padding-right: 30px !important;
+  padding-left: 30px !important;
 }
 
-/* Repo Next layout */
+/* New responsive containers on some pages */
+.container-lg {
+  max-width: 100% !important;
+  padding-right: 30px !important;
+  padding-left: 30px !important;
+}
+
+
+/*
+ * Profile pages
+ */
+
+.pinned-repo-item {
+  width: calc(50% - 10px) !important;
+}
+.org-pinned-repos-list .pinned-repo-item {
+  width: calc(33.3% - 10px) !important;
+}
+
+.u-photo {
+  max-width: 250px;
+}
+.u-photo .avatar {
+  width: 100% !important;
+  height: auto !important;
+}
+
+
+/*
+ * Repo-specific stuff
+ */
 
 .repository-content {
   width: 100% !important;
 }
 
-.repository-with-sidebar {
-  padding-right: 60px !important;
-}
-
-.repository-with-sidebar .repository-sidebar {
-  margin-right: -60px !important;
-}
-
-.summary-stats,
-.authors-and-code {
-  display: table;
-  width: 100%;
-}
-
-.summary-stats li {
-  width: 25%;
-}
-
-.authors-and-code .section {
-  width: 50%;
-}
-
-/* Repo Next Code page */
-
-.with-full-navigation {
-  padding-right: 190px !important;
-}
-
-.with-full-navigation .repository-sidebar {
-  margin-right: -190px !important;
+/* Undo container changes for the Projects tab on repos which have unnecessary nested container-lg's */
+.repository-content > .container-lg {
+  padding-right: 0 !important;
+  padding-left: 0 !important;
 }
 
 /* Issues/PRs */
-
 .discussion-sidebar {
   width: 220px !important;
 }
-
 .discussion-timeline {
   width: calc(100% - 240px) !important;
+}
+/* Undo for profile timeline */
+.contribution-activity-listing .discussion-timeline {
+  width: 100% !important;
 }
 
 /* Fix #18 - props: @auscompgeek */
@@ -57,7 +67,10 @@
   clear: left !important;
 }
 
-/* New issues and Dashboard */
+
+/*
+ * Issues & Dashboard
+ */
 
 #dashboard,
 .new-issue-form {
@@ -87,38 +100,14 @@ button.discussion-sidebar-toggle {
   margin-right: 360px !important;
 }
 
-/* Settings */
-/* This should be refactored to use our grid.scss styles anyway, thus negating these styles. */
-
-.settings-content,
-.repo-settings-content {
-  float: none !important;
-  width: auto !important;
-  overflow: auto !important; /* required to clear the floats that the float avoided */
-}
-.container > .settings-content,
-.repo-settings-content {
-  margin-left: 260px !important;
+/* Commits: extended message under "..." */
+.commit-desc pre {
+  max-width: none;
 }
 
-#repo-settings .menu-container {
-  width: 240px !important;
-}
-
+/* Alert messages */
 #js-flash-container .flash-messages {
   width: 100% !important;
   padding-left: 30px !important;
   padding-right: 30px !important;
-}
-
-/* Profile page */
-
-/* Profile avatar tooltip */
-.u-photo .avatar {
-  width: 230px !important;
-}
-
-/* Commits: extended message under "..." */
-.commit-desc pre {
-  max-width: none;
 }

--- a/github-wide.css
+++ b/github-wide.css
@@ -67,6 +67,11 @@
   clear: left !important;
 }
 
+/* Network graph */
+#network {
+  max-width: 730px;
+}
+
 
 /*
  * Issues & Dashboard


### PR DESCRIPTION
- Better code comments and organization of styles.
- Account for new `.container-lg` used on more pages by sharing the general `.container` styles. This fixes profile pages, Marketplace content, and site header not going full-width.
- Update profile pages with improved profile photo placement and fixed pinned repos.
- Removed all settings overrides; they're now entirely unnecessary in my testing.
- Remove old GitHub "repo next" styles.
- Adds `max-width` to network graph to close #44 and fix #50