### PR TITLE
Update github-wide.css for compatibility with octotree

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -4,6 +4,10 @@
   padding-right: 30px !important;
 }
 
+.container-lg {
+	max-width: inherit !important;
+}
+
 /* Repo Next layout */
 
 .repository-content {


### PR DESCRIPTION
To provide compatibility with [octotree](https://github.com/ovity/octotree)

Ref: https://github.com/ovity/octotree/issues/497#issuecomment-390162540

Resolves #58