### PR TITLE
fix user-status-container overflow on public profile page

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -27,7 +27,8 @@
   width: calc(33.3% - 10px) !important;
 }
 
-.u-photo {
+.u-photo,
+.user-status-container {
   max-width: 250px;
 }
 .u-photo .avatar {


### PR DESCRIPTION
current problem:
![2019-02-14 1 _li](https://user-images.githubusercontent.com/1256090/52818698-bec89980-30a7-11e9-959c-9800132f880a.jpg)


fixes the overflow