### PR TITLE
Most CSS styles can be converted to uBlock Origin's format nowadays

### DIFF
--- a/github-wide.txt
+++ b/github-wide.txt
@@ -15,14 +15,14 @@ github.com##.Header:style(padding-right: 30px !important; padding-left: 30px !im
 ! Profile pages
 github.com##.pinned-repo-item:style(width: calc(50% - 10px) !important)
 github.com##.org-pinned-repos-list .pinned-repo-item:style(width: calc(33.3% - 10px) !important)
-github.com##.u-photo,
+github.com##.u-photo:style(max-width: 250px)
 github.com##.user-status-container:style(max-width: 250px)
 github.com##.u-photo .avatar:style(width: 100% !important; height: auto !important)
 
 ! Repo-specific stuff
 github.com##.repository-content:style(width: 100% !important)
 
-! Undo container changes for the Projects tab on repos which have unnecessary nested container-lg's */
+! Undo container changes for the Projects tab on repos which have unnecessary nested container-lg's
 github.com##.repository-content > .container-lg:style(padding-right: 0 !important; padding-left: 0 !important)
 
 ! Issues/PRs

--- a/github-wide.txt
+++ b/github-wide.txt
@@ -1,0 +1,50 @@
+! Title: GitHub Wide — uBlock Origin version
+! Version: 11July2019v1
+! Updates: 30 days
+
+! Basic layout
+github.com##.container:style(width: 100% !important; padding-right: 30px !important; padding-left: 30px !important)
+
+! Responsive containers on some pages
+github.com##.container-lg:style(max-width: 100% !important; padding-right: 30px !important; padding-left: 30px !important)
+github.com##.container-xl:style(max-width: 100% !important; padding-right: 30px !important; padding-left: 30px !important)
+
+! Match the header to container padding
+github.com##.Header:style(padding-right: 30px !important; padding-left: 30px !important)
+
+! Profile pages
+github.com##.pinned-repo-item:style(width: calc(50% - 10px) !important)
+github.com##.org-pinned-repos-list .pinned-repo-item:style(width: calc(33.3% - 10px) !important)
+github.com##.u-photo,
+github.com##.user-status-container:style(max-width: 250px)
+github.com##.u-photo .avatar:style(width: 100% !important; height: auto !important)
+
+! Repo-specific stuff
+github.com##.repository-content:style(width: 100% !important)
+
+! Undo container changes for the Projects tab on repos which have unnecessary nested container-lg's */
+github.com##.repository-content > .container-lg:style(padding-right: 0 !important; padding-left: 0 !important)
+
+! Issues/PRs
+github.com##.discussion-sidebar:style(width: 280px !important)
+github.com##.discussion-timeline:style(width: calc(100% - 300px) !important)
+! Undo for profile timeline 
+github.com##.contribution-activity-listing .discussion-timeline:style(width: 100% !important)
+
+! Fix #18 - props: @auscompgeek
+github.com##.file-header:after:style(clear: left !important)
+
+! Network graph
+github.com###network:style(max-width: 730px)
+
+! Issues & Dashboard
+github.com###dashboard:style(position: relative !important)
+github.com##.new-issue-form:style(position: relative !important)
+github.com##.new-issue-form .discussion-sidebar:style(position: absolute !important; top: 0 !important; right: 0 !important)
+github.com##button.discussion-sidebar-toggle:style(width: 100% !important)
+github.com##.timeline-new-comment:style(max-width: none !important)
+! Commits: extended message under "..."
+github.com##.commit-desc pre:style(max-width: none)
+
+! Alert messages
+github.com###js-flash-container .flash-messages:style(width: 100% !important; padding-left: 30px !important; padding-right: 30px !important)


### PR DESCRIPTION
A couple or three years ago, uBlock Origin and AdGuard began to include support for editing CSS values, so indeed I believe that almost all Stylus userstyles (except for those that rely on external images) can be converted to their format with a bit of Ctrl+H. This way people won't need to use userstyle-specific extensions, when they instead can use more broad extensions with a lot fewer privacy scandals.

I also suppose it deserves mention that I've for some time now included entries from you guys' userscript (with creditation) in [one of my uBlock Origin lists](https://github.com/DandelionSprout/adfilt/blob/master/Dandelion%20Sprout's%20Website%20Stretcher.txt#L255), although the list isn't widely used, and the entries  I originally borrowed have by now also received some additions and changes of my own.

For this pull request and information notice, I made a straight conversion of the *GitHub Wide* userscript, although I believe that the entries from *Gist Wide* should also be incorporable without affecting the *GitHub Wide* entries to any real degree.