### PR TITLE
Remove width overrides for issues sidebar/timeline

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -58,13 +58,6 @@
   padding-left: 0 !important;
 }
 
-/* Issues/PRs */
-.discussion-sidebar {
-  width: 280px !important;
-}
-.discussion-timeline {
-  width: calc(100% - 300px) !important;
-}
 /* Undo for profile timeline */
 .contribution-activity-listing .discussion-timeline {
   width: 100% !important;


### PR DESCRIPTION
A recent change to GitHub changed the way the page layout is calculated, and they seem to be using a standard framework for alignment now. This makes these width calculations redundant.

Closes https://github.com/mdo/github-wide/issues/66