### PR TITLE
show longer repository names on the notifications page

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -113,3 +113,11 @@ button.discussion-sidebar-toggle {
 .css-truncate .css-truncate-target {
   max-width: 90%
 }
+
+.notifications .list-group-item-name {
+  max-width: 75%;
+}
+
+.notifications .list-group-item-name a {
+  max-width: 100%;
+}

--- a/github-wide.css
+++ b/github-wide.css
@@ -108,3 +108,8 @@ button.discussion-sidebar-toggle {
   padding-left: 30px !important;
   padding-right: 30px !important;
 }
+
+/* Notifications */
+.css-truncate .css-truncate-target {
+  max-width: 90%
+}


### PR DESCRIPTION
This PR shows the repository names on the notifications page with a width of 90% of the available space instead of a fixed width of 125px.